### PR TITLE
Fix concurrency config key

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -70,7 +70,7 @@ def run_scheduler(tool_config, credential_manager_factory, batch_manager_factory
     job_queue = Queue()
 
     threads = []
-    for i in range(tool_config['max_cuncurrent_jobs']):
+    for i in range(tool_config['max_concurrent_jobs']):
         t = threading.Thread(
             target=worker, 
             args=(job_queue, credential_manager_factory, batch_manager_factory)

--- a/tool_configs.yaml
+++ b/tool_configs.yaml
@@ -21,7 +21,7 @@ shared_summaries_folder: summaries
 shared_completed_folder: archived
 shared_wip_folder: wip
 scheduler_frequency: 60
-max_cuncurrent_jobs: 5
+max_concurrent_jobs: 5
 stuck_file_timeout: 7200
 
 # Services


### PR DESCRIPTION
## Summary
- correct the scheduler's configuration key to `max_concurrent_jobs`

## Testing
- `python -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_b_6851d94c431883219263ee560e1442ae