### PR TITLE
Fix duplicate streamlit import

### DIFF
--- a/src/streamlit_setup.py
+++ b/src/streamlit_setup.py
@@ -3,7 +3,6 @@ logger = logging.getLogger(__name__)
 
 import pandas as pd
 import streamlit as st
-import streamlit as st
 import streamlit_authenticator as stauth
 from streamlit_authenticator.utilities.hasher import Hasher
 from src.setup import load_config, setup_logging, CredentialManager


### PR DESCRIPTION
## Summary
- remove duplicated import of `streamlit` in `streamlit_setup.py`
- run `ruff` lint checks for duplicate imports

## Testing
- `ruff check --select F811 src`

------
https://chatgpt.com/codex/tasks/task_b_6851d954bd4c8321b0f2b373cae32569